### PR TITLE
82 technical debt rewrite test wo using eval for 33 tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.12]
+        python-version: [3.10.14, 3.11, 3.12]
 
     steps:
       - name: Checkout code

--- a/tests/3.3/test_33_a.py
+++ b/tests/3.3/test_33_a.py
@@ -1,6 +1,5 @@
-import math
-from math import pow
-from types import CodeType
+from types import ModuleType
+from typing import Dict, List, Set, Tuple, Union
 
 import pytest
 
@@ -9,25 +8,33 @@ from tests.data.test_data_33 import a_test_data
 MEMORY_LIMIT = 64  # RAM в MB
 TIME_LIMIT = 1  # Временной лимит в сек
 
+OUTPUT_TYPES = Union[
+    str,
+    List[Tuple[str, int]],
+    List[int],
+    List[List[int]],
+    Set[int],
+    Dict[str, Union[int, List[int]]],
+]
+
 
 @pytest.mark.memory_limit(MEMORY_LIMIT)
 @pytest.mark.time_limit(TIME_LIMIT)
 @pytest.mark.parametrize(
-    "variables, expected_output, _",  # _ - название теста
+    "input_data, expected_output, _",  # _ - название теста
     a_test_data,
     ids=[i[2] for i in a_test_data],  # Считываем названия тестов
 )
-def test_comprehensions(
-    setup_environment_comprehension: CodeType,
-    variables: dict,
-    expected_output: str,
+def test_input_output(
+    setup_environment: Tuple[ModuleType, str],
+    input_data: Dict[str, Union[str, int, List[int]]],
+    expected_output: OUTPUT_TYPES,
     _: str,
 ) -> None:
-    # Считываем код для проверки и компилируем его из строки в код
-    to_execute = setup_environment_comprehension
-    safe_globals = {
-        "__builtins__": {"math.pow": math.pow, "pow": pow, "range": range}
-    }
-    printed_output = eval(to_execute, safe_globals, variables)
 
-    assert printed_output == expected_output
+    variable_values = [value for value in input_data.values()]
+    wrapped_module, _ = setup_environment
+
+    returned_output = wrapped_module.main(*variable_values)
+
+    assert returned_output == expected_output

--- a/tests/3.3/test_33_b.py
+++ b/tests/3.3/test_33_b.py
@@ -1,4 +1,5 @@
-from types import CodeType
+from types import ModuleType
+from typing import Dict, List, Set, Tuple, Union
 
 import pytest
 
@@ -7,23 +8,33 @@ from tests.data.test_data_33 import b_test_data
 MEMORY_LIMIT = 64  # RAM в MB
 TIME_LIMIT = 1  # Временной лимит в сек
 
+OUTPUT_TYPES = Union[
+    str,
+    List[Tuple[str, int]],
+    List[int],
+    List[List[int]],
+    Set[int],
+    Dict[str, Union[int, List[int]]],
+]
+
 
 @pytest.mark.memory_limit(MEMORY_LIMIT)
 @pytest.mark.time_limit(TIME_LIMIT)
 @pytest.mark.parametrize(
-    "variables, expected_output, _",  # _ - название теста
+    "input_data, expected_output, _",  # _ - название теста
     b_test_data,
     ids=[i[2] for i in b_test_data],  # Считываем названия тестов
 )
-def test_comprehensions(
-    setup_environment_comprehension: CodeType,
-    variables: dict,
-    expected_output: str,
+def test_input_output(
+    setup_environment: Tuple[ModuleType, str],
+    input_data: Dict[str, Union[str, int, List[int]]],
+    expected_output: OUTPUT_TYPES,
     _: str,
 ) -> None:
-    # Считываем код для проверки и компилируем его из строки в код
-    to_execute = setup_environment_comprehension
-    safe_globals = {"__builtins__": {"range": range}}
-    printed_output = eval(to_execute, safe_globals, variables)
 
-    assert printed_output == expected_output
+    variable_values = [value for value in input_data.values()]
+    wrapped_module, _ = setup_environment
+
+    returned_output = wrapped_module.main(*variable_values)
+
+    assert returned_output == expected_output

--- a/tests/3.3/test_33_c.py
+++ b/tests/3.3/test_33_c.py
@@ -1,4 +1,5 @@
-from types import CodeType
+from types import ModuleType
+from typing import Dict, List, Set, Tuple, Union
 
 import pytest
 
@@ -7,23 +8,33 @@ from tests.data.test_data_33 import c_test_data
 MEMORY_LIMIT = 64  # RAM в MB
 TIME_LIMIT = 1  # Временной лимит в сек
 
+OUTPUT_TYPES = Union[
+    str,
+    List[Tuple[str, int]],
+    List[int],
+    List[List[int]],
+    Set[int],
+    Dict[str, Union[int, List[int]]],
+]
+
 
 @pytest.mark.memory_limit(MEMORY_LIMIT)
 @pytest.mark.time_limit(TIME_LIMIT)
 @pytest.mark.parametrize(
-    "variables, expected_output, _",  # _ - название теста
+    "input_data, expected_output, _",  # _ - название теста
     c_test_data,
     ids=[i[2] for i in c_test_data],  # Считываем названия тестов
 )
-def test_comprehensions(
-    setup_environment_comprehension: CodeType,
-    variables: dict,
-    expected_output: str,
+def test_input_output(
+    setup_environment: Tuple[ModuleType, str],
+    input_data: Dict[str, Union[str, int, List[int]]],
+    expected_output: OUTPUT_TYPES,
     _: str,
 ) -> None:
-    # Считываем код для проверки и компилируем его из строки в код
-    to_execute = setup_environment_comprehension
-    safe_globals = {"__builtins__": {"len": len}}
-    printed_output = eval(to_execute, safe_globals, variables)
 
-    assert printed_output == expected_output
+    variable_values = [value for value in input_data.values()]
+    wrapped_module, _ = setup_environment
+
+    returned_output = wrapped_module.main(*variable_values)
+
+    assert returned_output == expected_output

--- a/tests/3.3/test_33_d.py
+++ b/tests/3.3/test_33_d.py
@@ -1,4 +1,5 @@
-from types import CodeType
+from types import ModuleType
+from typing import Dict, List, Set, Tuple, Union
 
 import pytest
 
@@ -7,23 +8,33 @@ from tests.data.test_data_33 import d_test_data
 MEMORY_LIMIT = 64  # RAM в MB
 TIME_LIMIT = 1  # Временной лимит в сек
 
+OUTPUT_TYPES = Union[
+    str,
+    List[Tuple[str, int]],
+    List[int],
+    List[List[int]],
+    Set[int],
+    Dict[str, Union[int, List[int]]],
+]
+
 
 @pytest.mark.memory_limit(MEMORY_LIMIT)
 @pytest.mark.time_limit(TIME_LIMIT)
 @pytest.mark.parametrize(
-    "variables, expected_output, _",  # _ - название теста
+    "input_data, expected_output, _",  # _ - название теста
     d_test_data,
     ids=[i[2] for i in d_test_data],  # Считываем названия тестов
 )
-def test_comprehensions(
-    setup_environment_comprehension: CodeType,
-    variables: dict,
-    expected_output: str,
+def test_input_output(
+    setup_environment: Tuple[ModuleType, str],
+    input_data: Dict[str, Union[str, int, List[int]]],
+    expected_output: OUTPUT_TYPES,
     _: str,
 ) -> None:
-    # Считываем код для проверки и компилируем его из строки в код
-    to_execute = setup_environment_comprehension
-    safe_globals = {"__builtins__": {}}
-    printed_output = eval(to_execute, safe_globals, variables)
 
-    assert printed_output == expected_output
+    variable_values = [value for value in input_data.values()]
+    wrapped_module, _ = setup_environment
+
+    returned_output = wrapped_module.main(*variable_values)
+
+    assert returned_output == expected_output

--- a/tests/3.3/test_33_e.py
+++ b/tests/3.3/test_33_e.py
@@ -1,6 +1,5 @@
-import math
-from math import pow
-from types import CodeType
+from types import ModuleType
+from typing import Dict, List, Set, Tuple, Union
 
 import pytest
 
@@ -9,25 +8,33 @@ from tests.data.test_data_33 import e_test_data
 MEMORY_LIMIT = 64  # RAM в MB
 TIME_LIMIT = 1  # Временной лимит в сек
 
+OUTPUT_TYPES = Union[
+    str,
+    List[Tuple[str, int]],
+    List[int],
+    List[List[int]],
+    Set[int],
+    Dict[str, Union[int, List[int]]],
+]
+
 
 @pytest.mark.memory_limit(MEMORY_LIMIT)
 @pytest.mark.time_limit(TIME_LIMIT)
 @pytest.mark.parametrize(
-    "variables, expected_output, _",  # _ - название теста
+    "input_data, expected_output, _",  # _ - название теста
     e_test_data,
     ids=[i[2] for i in e_test_data],  # Считываем названия тестов
 )
-def test_comprehensions(
-    setup_environment_comprehension: CodeType,
-    variables: dict,
-    expected_output: str,
+def test_input_output(
+    setup_environment: Tuple[ModuleType, str],
+    input_data: Dict[str, Union[str, int, List[int]]],
+    expected_output: OUTPUT_TYPES,
     _: str,
 ) -> None:
-    # Считываем код для проверки и компилируем его из строки в код
-    to_execute = setup_environment_comprehension
-    safe_globals = {
-        "__builtins__": {"int": int, "math.pow": math.pow, "pow": pow}
-    }
-    printed_output = eval(to_execute, safe_globals, variables)
 
-    assert printed_output == expected_output
+    variable_values = [value for value in input_data.values()]
+    wrapped_module, _ = setup_environment
+
+    returned_output = wrapped_module.main(*variable_values)
+
+    assert returned_output == expected_output

--- a/tests/3.3/test_33_f.py
+++ b/tests/3.3/test_33_f.py
@@ -1,4 +1,5 @@
-from types import CodeType
+from types import ModuleType
+from typing import Dict, List, Set, Tuple, Union
 
 import pytest
 
@@ -7,23 +8,33 @@ from tests.data.test_data_33 import f_test_data
 MEMORY_LIMIT = 64  # RAM в MB
 TIME_LIMIT = 1  # Временной лимит в сек
 
+OUTPUT_TYPES = Union[
+    str,
+    List[Tuple[str, int]],
+    List[int],
+    List[List[int]],
+    Set[int],
+    Dict[str, Union[int, List[int]]],
+]
+
 
 @pytest.mark.memory_limit(MEMORY_LIMIT)
 @pytest.mark.time_limit(TIME_LIMIT)
 @pytest.mark.parametrize(
-    "variables, expected_output, _",  # _ - название теста
+    "input_data, expected_output, _",  # _ - название теста
     f_test_data,
     ids=[i[2] for i in f_test_data],  # Считываем названия тестов
 )
-def test_comprehensions(
-    setup_environment_comprehension: CodeType,
-    variables: dict,
-    expected_output: str,
+def test_input_output(
+    setup_environment: Tuple[ModuleType, str],
+    input_data: Dict[str, Union[str, int, List[int]]],
+    expected_output: OUTPUT_TYPES,
     _: str,
 ) -> None:
-    # Считываем код для проверки и компилируем его из строки в код
-    to_execute = setup_environment_comprehension
-    safe_globals = {"__builtins__": {"sum": sum}}
-    printed_output = eval(to_execute, safe_globals, variables)
 
-    assert printed_output == expected_output
+    variable_values = [value for value in input_data.values()]
+    wrapped_module, _ = setup_environment
+
+    returned_output = wrapped_module.main(*variable_values)
+
+    assert returned_output == expected_output

--- a/tests/3.3/test_33_g.py
+++ b/tests/3.3/test_33_g.py
@@ -1,4 +1,5 @@
-from types import CodeType
+from types import ModuleType
+from typing import Dict, List, Set, Tuple, Union
 
 import pytest
 
@@ -7,23 +8,33 @@ from tests.data.test_data_33 import g_test_data
 MEMORY_LIMIT = 64  # RAM в MB
 TIME_LIMIT = 1  # Временной лимит в сек
 
+OUTPUT_TYPES = Union[
+    str,
+    List[Tuple[str, int]],
+    List[int],
+    List[List[int]],
+    Set[int],
+    Dict[str, Union[int, List[int]]],
+]
+
 
 @pytest.mark.memory_limit(MEMORY_LIMIT)
 @pytest.mark.time_limit(TIME_LIMIT)
 @pytest.mark.parametrize(
-    "variables, expected_output, _",  # _ - название теста
+    "input_data, expected_output, _",  # _ - название теста
     g_test_data,
     ids=[i[2] for i in g_test_data],  # Считываем названия тестов
 )
-def test_comprehensions(
-    setup_environment_comprehension: CodeType,
-    variables: dict,
-    expected_output: str,
+def test_input_output(
+    setup_environment: Tuple[ModuleType, str],
+    input_data: Dict[str, Union[str, int, List[int]]],
+    expected_output: OUTPUT_TYPES,
     _: str,
 ) -> None:
-    # Считываем код для проверки и компилируем его из строки в код
-    to_execute = setup_environment_comprehension
-    safe_globals = {"__builtins__": {"int": int, "range": range}}
-    printed_output = eval(to_execute, safe_globals, variables)
 
-    assert printed_output == expected_output
+    variable_values = [value for value in input_data.values()]
+    wrapped_module, _ = setup_environment
+
+    returned_output = wrapped_module.main(*variable_values)
+
+    assert returned_output == expected_output

--- a/tests/3.3/test_33_h.py
+++ b/tests/3.3/test_33_h.py
@@ -1,4 +1,5 @@
-from types import CodeType
+from types import ModuleType
+from typing import Dict, List, Set, Tuple, Union
 
 import pytest
 
@@ -7,23 +8,33 @@ from tests.data.test_data_33 import h_test_data
 MEMORY_LIMIT = 64  # RAM в MB
 TIME_LIMIT = 1  # Временной лимит в сек
 
+OUTPUT_TYPES = Union[
+    str,
+    List[Tuple[str, int]],
+    List[int],
+    List[List[int]],
+    Set[int],
+    Dict[str, Union[int, List[int]]],
+]
+
 
 @pytest.mark.memory_limit(MEMORY_LIMIT)
 @pytest.mark.time_limit(TIME_LIMIT)
 @pytest.mark.parametrize(
-    "variables, expected_output, _",  # _ - название теста
+    "input_data, expected_output, _",  # _ - название теста
     h_test_data,
     ids=[i[2] for i in h_test_data],  # Считываем названия тестов
 )
-def test_comprehensions(
-    setup_environment_comprehension: CodeType,
-    variables: dict,
-    expected_output: str,
+def test_input_output(
+    setup_environment: Tuple[ModuleType, str],
+    input_data: Dict[str, Union[str, int, List[int]]],
+    expected_output: OUTPUT_TYPES,
     _: str,
 ) -> None:
-    # Считываем код для проверки и компилируем его из строки в код
-    to_execute = setup_environment_comprehension
-    safe_globals = {"__builtins__": {}}
-    printed_output = eval(to_execute, safe_globals, variables)
 
-    assert printed_output == expected_output
+    variable_values = [value for value in input_data.values()]
+    wrapped_module, _ = setup_environment
+
+    returned_output = wrapped_module.main(*variable_values)
+
+    assert returned_output == expected_output

--- a/tests/3.3/test_33_i.py
+++ b/tests/3.3/test_33_i.py
@@ -1,4 +1,5 @@
-from types import CodeType
+from types import ModuleType
+from typing import Dict, List, Set, Tuple, Union
 
 import pytest
 
@@ -7,25 +8,33 @@ from tests.data.test_data_33 import i_test_data
 MEMORY_LIMIT = 64  # RAM в MB
 TIME_LIMIT = 1  # Временной лимит в сек
 
+OUTPUT_TYPES = Union[
+    str,
+    List[Tuple[str, int]],
+    List[int],
+    List[List[int]],
+    Set[int],
+    Dict[str, Union[int, List[int]]],
+]
+
 
 @pytest.mark.memory_limit(MEMORY_LIMIT)
 @pytest.mark.time_limit(TIME_LIMIT)
 @pytest.mark.parametrize(
-    "variables, expected_output, _",  # _ - название теста
+    "input_data, expected_output, _",  # _ - название теста
     i_test_data,
     ids=[i[2] for i in i_test_data],  # Считываем названия тестов
 )
-def test_comprehensions(
-    setup_environment_comprehension: CodeType,
-    variables: dict,
-    expected_output: str,
+def test_input_output(
+    setup_environment: Tuple[ModuleType, str],
+    input_data: Dict[str, Union[str, int, List[int]]],
+    expected_output: OUTPUT_TYPES,
     _: str,
 ) -> None:
-    # Считываем код для проверки и компилируем его из строки в код
-    to_execute = setup_environment_comprehension
-    safe_globals = {
-        "__builtins__": {"map": map, "str": str, "set": set, "sorted": sorted}
-    }
-    printed_output = eval(to_execute, safe_globals, variables)
 
-    assert printed_output == expected_output
+    variable_values = [value for value in input_data.values()]
+    wrapped_module, _ = setup_environment
+
+    returned_output = wrapped_module.main(*variable_values)
+
+    assert returned_output == expected_output

--- a/tests/3.3/test_33_j.py
+++ b/tests/3.3/test_33_j.py
@@ -1,4 +1,5 @@
-from types import CodeType
+from types import ModuleType
+from typing import Dict, List, Set, Tuple, Union
 
 import pytest
 
@@ -7,23 +8,33 @@ from tests.data.test_data_33 import j_test_data
 MEMORY_LIMIT = 64  # RAM в MB
 TIME_LIMIT = 1  # Временной лимит в сек
 
+OUTPUT_TYPES = Union[
+    str,
+    List[Tuple[str, int]],
+    List[int],
+    List[List[int]],
+    Set[int],
+    Dict[str, Union[int, List[int]]],
+]
+
 
 @pytest.mark.memory_limit(MEMORY_LIMIT)
 @pytest.mark.time_limit(TIME_LIMIT)
 @pytest.mark.parametrize(
-    "variables, expected_output, _",  # _ - название теста
+    "input_data, expected_output, _",  # _ - название теста
     j_test_data,
     ids=[i[2] for i in j_test_data],  # Считываем названия тестов
 )
-def test_comprehensions(
-    setup_environment_comprehension: CodeType,
-    variables: dict,
-    expected_output: str,
+def test_input_output(
+    setup_environment: Tuple[ModuleType, str],
+    input_data: Dict[str, Union[str, int, List[int]]],
+    expected_output: OUTPUT_TYPES,
     _: str,
 ) -> None:
-    # Считываем код для проверки и компилируем его из строки в код
-    to_execute = setup_environment_comprehension
-    safe_globals = {"__builtins__": {}}
-    printed_output = eval(to_execute, safe_globals, variables)
 
-    assert printed_output == expected_output
+    variable_values = [value for value in input_data.values()]
+    wrapped_module, _ = setup_environment
+
+    returned_output = wrapped_module.main(*variable_values)
+
+    assert returned_output == expected_output

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,8 +1,7 @@
-import ast
 import os
 import signal
 from io import StringIO
-from types import CodeType, FrameType, ModuleType
+from types import FrameType, ModuleType
 from typing import Any, Callable, Tuple, Union
 
 import psutil
@@ -140,7 +139,7 @@ def assert_equal(
     wrapped_module: ModuleType,
     monkeypatch: Any,
     mock_input_text: str,
-    expected_output: Union[str, set, tuple, list],
+    expected_output: Union[str, set, tuple, list]
 ) -> None:
     """
     Запускает тест с заданным вводом и проверяет вывод.
@@ -188,7 +187,7 @@ def get_tested_file_details(request: FixtureRequest) -> Tuple[str, str]:
     # Название папки с тестируемым кодом
     file_dir = os.path.basename(dir_name)
 
-    # Получаем имя тестируемого файла "test_21_a.py" -> "a.py"
+    # Получаем имя тестируемого файла "test_21_a.py" -> "21_a.py"
     tested_file_name = file_name.split("test_")[-1]
 
     # Путь к тестируемому файлу для обертывания в функцию
@@ -196,30 +195,7 @@ def get_tested_file_details(request: FixtureRequest) -> Tuple[str, str]:
         abs_code_dir, "solutions", file_dir, tested_file_name
     )
 
-    # Получаем букву тестируемого файла "a.py" -> ["a", ""]
-    tested_file_letter = tested_file_name.split(".py")[0]
+    # Получаем букву тестируемого файла "21_a.py" -> ["21_a", ""]
+    tested_file_name = tested_file_name.split(".py")[0]
 
-    return path_to_test_file, tested_file_letter
-
-
-def compile_string(path_to_solution: str) -> CodeType:
-    """
-    Читает код из файла и компилирует его в объект типа CodeType.
-
-    Аргументы:
-        path_to_solution (str): Путь к файлу, содержащему код.
-
-    Возвращает:
-        CodeType: Скомпилированный код в виде объекта CodeType.
-    """
-    with open(path_to_solution, "r", encoding="UTF-8") as file:
-        code = file.read()
-
-    parsed = ast.parse(code, mode="eval")
-    white_list = (ast.ListComp, ast.DictComp, ast.SetComp, ast.Call)
-
-    if isinstance(parsed.body, white_list):
-        compiled_code = compile(parsed, filename="<ast>", mode="eval")
-        return compiled_code
-
-    raise TypeError(f"Неправильный тип данных: {parsed.body}")
+    return path_to_test_file, tested_file_name


### PR DESCRIPTION
Тесты переписаны без `eval`, убраны костыли из `tests/utils.py` и `tests/conftest.py`